### PR TITLE
fix docker build fail because no 'gcc' command.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,6 +2,6 @@ FROM pytorch/pytorch:1.9.0-cuda10.2-cudnn7-runtime
 
 MAINTAINER Ryuichi YAMAMOTO <zryuichi@gmail.com>
 
-RUN apt-get update && apt-get install -y curl git libsamplerate0 libsndfile1 && apt-get clean
+RUN apt-get update && apt-get install -y curl git build-essential libsamplerate0 libsndfile1 && apt-get clean
 
 RUN pip install ttslearn


### PR DESCRIPTION
`docker build` fails because no 'gcc' command.
So I added `build-essential` package to docker image.

```sh
cd docker
docker build . -t ttslearn

...(omit)...

# ↓ error because of no 'gcc' command
unable to execute 'gcc': No such file or directory
error: command 'gcc' failed with exit status 1
----------------------------------------
ERROR: Failed building wheel for pysptk

...(omit)...

Successfully built ttslearn antlr4-python3-runtime audioread parallel-wavegan kaldiio resampy fastdtw gdown
Failed to build nnmnkwii pyopenjtalk pysptk pyworld
ERROR: Could not build wheels for nnmnkwii, pyopenjtalk, pyworld which use PEP 517 and cannot be installed directly
The command '/bin/sh -c pip install ttslearn' returned a non-zero code: 1
```
