### PR TITLE
Fix typos and add typo checker to GitHub Actions

### DIFF
--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -1,0 +1,19 @@
+---
+# yamllint disable rule:line-length
+name: check_typos
+
+on:  # yamllint disable-line rule:truthy
+  push:
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: typos-action
+        uses: crate-ci/typos@v1.1.7

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,10 @@
+# Instruction:  https://github.com/marketplace/actions/typos-action#getting-started
+[default.extend-words]
+JSUT = "JSUT"
+jsut = "jsut"
+inout = "inout"
+
+[default.extend-identifiers]
+
+[files]
+extend-exclude = []

--- a/extra_recipes/jsut/tacotron2_pwg/conf/hifigan_sr24k.yaml
+++ b/extra_recipes/jsut/tacotron2_pwg/conf/hifigan_sr24k.yaml
@@ -29,7 +29,7 @@ generator_params:
     channels: 512                         # Number of initial channels.
     kernel_size: 7                        # Kernel size of initial and final conv layers.
     upsample_scales: [10, 5, 3, 2]        # Upsampling scales.
-    upsample_kernal_sizes: [20, 10, 6, 4] # Kernel size for upsampling layers.
+    upsample_kernel_sizes: [20, 10, 6, 4] # Kernel size for upsampling layers.
     resblock_kernel_sizes: [3, 7, 11]     # Kernel size for residual blocks.
     resblock_dilations:                   # Dilations for residual blocks.
         - [1, 3, 5]
@@ -38,7 +38,7 @@ generator_params:
     use_additional_convs: true            # Whether to use additional conv layer in residual blocks.
     bias: true                            # Whether to use bias parameter in conv.
     nonlinear_activation: "LeakyReLU"     # Nonlinear activation type.
-    nonlinear_activation_params:          # Nonlinear activation paramters.
+    nonlinear_activation_params:          # Nonlinear activation parameters.
         negative_slope: 0.1
     use_weight_norm: true                 # Whether to apply weight normalization.
 
@@ -56,7 +56,7 @@ discriminator_params:
     scale_discriminator_params:
         in_channels: 1                     # Number of input channels.
         out_channels: 1                    # Number of output channels.
-        kernel_sizes: [15, 41, 5, 3]       # List of kernal sizes.
+        kernel_sizes: [15, 41, 5, 3]       # List of kernel sizes.
         channels: 128                      # Initial number of channels.
         max_downsample_channels: 1024      # Maximum number of channels in downsampling conv layers.
         max_groups: 16                     # Maximum number of groups in downsampling conv layers.
@@ -70,13 +70,13 @@ discriminator_params:
     period_discriminator_params:
         in_channels: 1                     # Number of input channels.
         out_channels: 1                    # Number of output channels.
-        kernel_sizes: [5, 3]               # List of kernal sizes.
+        kernel_sizes: [5, 3]               # List of kernel sizes.
         channels: 32                       # Initial number of channels.
         downsample_scales: [3, 3, 3, 3, 1] # Downsampling scales.
         max_downsample_channels: 1024      # Maximum number of channels in downsampling conv layers.
         bias: true                         # Whether to use bias parameter in conv layer."
         nonlinear_activation: "LeakyReLU"  # Nonlinear activation.
-        nonlinear_activation_params:       # Nonlinear activation paramters.
+        nonlinear_activation_params:       # Nonlinear activation parameters.
             negative_slope: 0.1
         use_weight_norm: true              # Whether to apply weight normalization.
         use_spectral_norm: false           # Whether to apply spectral normalization.

--- a/extra_recipes/jsut/tacotron2_pwg/conf/hifigan_sr24k_fine.yaml
+++ b/extra_recipes/jsut/tacotron2_pwg/conf/hifigan_sr24k_fine.yaml
@@ -30,7 +30,7 @@ generator_params:
     channels: 512                         # Number of initial channels.
     kernel_size: 7                        # Kernel size of initial and final conv layers.
     upsample_scales: [10, 5, 3, 2]        # Upsampling scales.
-    upsample_kernal_sizes: [20, 10, 6, 4] # Kernel size for upsampling layers.
+    upsample_kernel_sizes: [20, 10, 6, 4] # Kernel size for upsampling layers.
     resblock_kernel_sizes: [3, 7, 11]     # Kernel size for residual blocks.
     resblock_dilations:                   # Dilations for residual blocks.
         - [1, 3, 5]
@@ -39,7 +39,7 @@ generator_params:
     use_additional_convs: true            # Whether to use additional conv layer in residual blocks.
     bias: true                            # Whether to use bias parameter in conv.
     nonlinear_activation: "LeakyReLU"     # Nonlinear activation type.
-    nonlinear_activation_params:          # Nonlinear activation paramters.
+    nonlinear_activation_params:          # Nonlinear activation parameters.
         negative_slope: 0.1
     use_weight_norm: true                 # Whether to apply weight normalization.
 
@@ -57,7 +57,7 @@ discriminator_params:
     scale_discriminator_params:
         in_channels: 1                     # Number of input channels.
         out_channels: 1                    # Number of output channels.
-        kernel_sizes: [15, 41, 5, 3]       # List of kernal sizes.
+        kernel_sizes: [15, 41, 5, 3]       # List of kernel sizes.
         channels: 128                      # Initial number of channels.
         max_downsample_channels: 1024      # Maximum number of channels in downsampling conv layers.
         max_groups: 16                     # Maximum number of groups in downsampling conv layers.
@@ -71,13 +71,13 @@ discriminator_params:
     period_discriminator_params:
         in_channels: 1                     # Number of input channels.
         out_channels: 1                    # Number of output channels.
-        kernel_sizes: [5, 3]               # List of kernal sizes.
+        kernel_sizes: [5, 3]               # List of kernel sizes.
         channels: 32                       # Initial number of channels.
         downsample_scales: [3, 3, 3, 3, 1] # Downsampling scales.
         max_downsample_channels: 1024      # Maximum number of channels in downsampling conv layers.
         bias: true                         # Whether to use bias parameter in conv layer."
         nonlinear_activation: "LeakyReLU"  # Nonlinear activation.
-        nonlinear_activation_params:       # Nonlinear activation paramters.
+        nonlinear_activation_params:       # Nonlinear activation parameters.
             negative_slope: 0.1
         use_weight_norm: true              # Whether to apply weight normalization.
         use_spectral_norm: false           # Whether to apply spectral normalization.

--- a/extra_recipes/jvs/multispk_tacotron2_pwg/conf/hifigan_sr24k.yaml
+++ b/extra_recipes/jvs/multispk_tacotron2_pwg/conf/hifigan_sr24k.yaml
@@ -29,7 +29,7 @@ generator_params:
     channels: 512                         # Number of initial channels.
     kernel_size: 7                        # Kernel size of initial and final conv layers.
     upsample_scales: [10, 5, 3, 2]        # Upsampling scales.
-    upsample_kernal_sizes: [20, 10, 6, 4] # Kernel size for upsampling layers.
+    upsample_kernel_sizes: [20, 10, 6, 4] # Kernel size for upsampling layers.
     resblock_kernel_sizes: [3, 7, 11]     # Kernel size for residual blocks.
     resblock_dilations:                   # Dilations for residual blocks.
         - [1, 3, 5]
@@ -38,7 +38,7 @@ generator_params:
     use_additional_convs: true            # Whether to use additional conv layer in residual blocks.
     bias: true                            # Whether to use bias parameter in conv.
     nonlinear_activation: "LeakyReLU"     # Nonlinear activation type.
-    nonlinear_activation_params:          # Nonlinear activation paramters.
+    nonlinear_activation_params:          # Nonlinear activation parameters.
         negative_slope: 0.1
     use_weight_norm: true                 # Whether to apply weight normalization.
 
@@ -56,7 +56,7 @@ discriminator_params:
     scale_discriminator_params:
         in_channels: 1                     # Number of input channels.
         out_channels: 1                    # Number of output channels.
-        kernel_sizes: [15, 41, 5, 3]       # List of kernal sizes.
+        kernel_sizes: [15, 41, 5, 3]       # List of kernel sizes.
         channels: 128                      # Initial number of channels.
         max_downsample_channels: 1024      # Maximum number of channels in downsampling conv layers.
         max_groups: 16                     # Maximum number of groups in downsampling conv layers.
@@ -70,13 +70,13 @@ discriminator_params:
     period_discriminator_params:
         in_channels: 1                     # Number of input channels.
         out_channels: 1                    # Number of output channels.
-        kernel_sizes: [5, 3]               # List of kernal sizes.
+        kernel_sizes: [5, 3]               # List of kernel sizes.
         channels: 32                       # Initial number of channels.
         downsample_scales: [3, 3, 3, 3, 1] # Downsampling scales.
         max_downsample_channels: 1024      # Maximum number of channels in downsampling conv layers.
         bias: true                         # Whether to use bias parameter in conv layer."
         nonlinear_activation: "LeakyReLU"  # Nonlinear activation.
-        nonlinear_activation_params:       # Nonlinear activation paramters.
+        nonlinear_activation_params:       # Nonlinear activation parameters.
             negative_slope: 0.1
         use_weight_norm: true              # Whether to apply weight normalization.
         use_spectral_norm: false           # Whether to apply spectral normalization.

--- a/extra_recipes/jvs/multispk_tacotron2_pwg/conf/hifigan_sr24k_fine.yaml
+++ b/extra_recipes/jvs/multispk_tacotron2_pwg/conf/hifigan_sr24k_fine.yaml
@@ -30,7 +30,7 @@ generator_params:
     channels: 512                         # Number of initial channels.
     kernel_size: 7                        # Kernel size of initial and final conv layers.
     upsample_scales: [10, 5, 3, 2]        # Upsampling scales.
-    upsample_kernal_sizes: [20, 10, 6, 4] # Kernel size for upsampling layers.
+    upsample_kernel_sizes: [20, 10, 6, 4] # Kernel size for upsampling layers.
     resblock_kernel_sizes: [3, 7, 11]     # Kernel size for residual blocks.
     resblock_dilations:                   # Dilations for residual blocks.
         - [1, 3, 5]
@@ -39,7 +39,7 @@ generator_params:
     use_additional_convs: true            # Whether to use additional conv layer in residual blocks.
     bias: true                            # Whether to use bias parameter in conv.
     nonlinear_activation: "LeakyReLU"     # Nonlinear activation type.
-    nonlinear_activation_params:          # Nonlinear activation paramters.
+    nonlinear_activation_params:          # Nonlinear activation parameters.
         negative_slope: 0.1
     use_weight_norm: true                 # Whether to apply weight normalization.
 
@@ -57,7 +57,7 @@ discriminator_params:
     scale_discriminator_params:
         in_channels: 1                     # Number of input channels.
         out_channels: 1                    # Number of output channels.
-        kernel_sizes: [15, 41, 5, 3]       # List of kernal sizes.
+        kernel_sizes: [15, 41, 5, 3]       # List of kernel sizes.
         channels: 128                      # Initial number of channels.
         max_downsample_channels: 1024      # Maximum number of channels in downsampling conv layers.
         max_groups: 16                     # Maximum number of groups in downsampling conv layers.
@@ -71,13 +71,13 @@ discriminator_params:
     period_discriminator_params:
         in_channels: 1                     # Number of input channels.
         out_channels: 1                    # Number of output channels.
-        kernel_sizes: [5, 3]               # List of kernal sizes.
+        kernel_sizes: [5, 3]               # List of kernel sizes.
         channels: 32                       # Initial number of channels.
         downsample_scales: [3, 3, 3, 3, 1] # Downsampling scales.
         max_downsample_channels: 1024      # Maximum number of channels in downsampling conv layers.
         bias: true                         # Whether to use bias parameter in conv layer."
         nonlinear_activation: "LeakyReLU"  # Nonlinear activation.
-        nonlinear_activation_params:       # Nonlinear activation paramters.
+        nonlinear_activation_params:       # Nonlinear activation parameters.
             negative_slope: 0.1
         use_weight_norm: true              # Whether to apply weight normalization.
         use_spectral_norm: false           # Whether to apply spectral normalization.

--- a/ttslearn/dnntts/multistream.py
+++ b/ttslearn/dnntts/multistream.py
@@ -139,7 +139,7 @@ def multi_stream_mlpg(
     """
     T, D = inputs.shape
     if D != sum(stream_sizes):
-        raise RuntimeError("You probably have specified wrong dimention params.")
+        raise RuntimeError("You probably have specified wrong dimension params.")
     if streams is None:
         streams = [True] * len(stream_sizes)
 

--- a/ttslearn/dsp.py
+++ b/ttslearn/dsp.py
@@ -64,7 +64,7 @@ def world_log_f0_vuv(x, sr):
         ndarray: Log-F0 and V/UV.
     """
     f0, timeaxis = pyworld.dio(x, sr)
-    # (Optinal) Stonemask によってF0の推定結果をrefineする
+    # (Optional) Stonemask によってF0の推定結果をrefineする
     f0 = pyworld.stonemask(x, f0, timeaxis, sr)
     vuv = (f0 > 0).astype(np.float32)
 
@@ -102,7 +102,7 @@ def world_spss_params(x, sr, mgc_order=None):
         ndarray: WORLD features.
     """
     f0, timeaxis = pyworld.dio(x, sr)
-    # (Optinal) Stonemask によってF0の推定結果をrefineする
+    # (Optional) Stonemask によってF0の推定結果をrefineする
     f0 = pyworld.stonemask(x, f0, timeaxis, sr)
 
     sp = pyworld.cheaptrick(x, f0, timeaxis, sr)

--- a/ttslearn/notebook.py
+++ b/ttslearn/notebook.py
@@ -5,7 +5,7 @@ def get_cmap():
     """Gets the colormap (default: ``viridis``)
 
     The colormap can be set by the environment variable ``TTSLEARN_CMAP``
-    for convienence.
+    for convenience.
 
     Returns:
         str: The name of the current colormap.
@@ -35,7 +35,7 @@ def savefig(name, dpi=350, *args, **kwargs):
     """Saves the figure to a file.
 
     By default, a figure is saved as a .png file. The extension of the file can be set by
-    the environment variable ``TTSLEARN_EXT`` for convienence.
+    the environment variable ``TTSLEARN_EXT`` for convenience.
     If the environment variable ``TTSLEARN_SAVEFIG`` is set to 0, figures will not be saved
     and this function do nothing.
 

--- a/ttslearn/pretrained/__init__.py
+++ b/ttslearn/pretrained/__init__.py
@@ -72,8 +72,8 @@ def create_tts_engine(name, *args, **kwargs):
 
     Args:
         name (str): Pre-trained model name
-        args (list): Additional args for instanciation
-        kwargs (dict): Additional kwargs for instanciation
+        args (list): Additional args for instantiation
+        kwargs (dict): Additional kwargs for instantiation
 
     Returns:
         object: instance of TTS engine

--- a/ttslearn/wavenet/upsample.py
+++ b/ttslearn/wavenet/upsample.py
@@ -80,7 +80,7 @@ class ConvInUpsampleNetwork(nn.Module):
     Args:
         upsample_scales (list): list of scales to upsample
         cin_channels (int): number of input channels
-        aux_context_window (int): size of the auxilary context window
+        aux_context_window (int): size of the auxiliary context window
     """
 
     def __init__(self, upsample_scales, cin_channels, aux_context_window):
@@ -107,7 +107,7 @@ class ConvTransposeUpsampleNetwork(nn.Module):
 
     Args:
         upsample_scales (list): list of scales to upsample
-        aux_context_window (int): size of the auxilary context window
+        aux_context_window (int): size of the auxiliary context window
     """
 
     def __init__(self, upsample_scales, aux_context_window):


### PR DESCRIPTION
Fixed typos:

```txt
      2 error: `Optinal` should be `Optional`
      2 error: `auxilary` should be `auxiliary`
      2 error: `convienence` should be `convenience`
      1 error: `dimention` should be `dimension`
      2 error: `instanciation` should be `instantiation`
     12 error: `kernal` should be `kernel`
      8 error: `paramters` should be `parameters`
```