### PR TITLE
windows: use expanduser instread of os.environ["HOME"]

### DIFF
--- a/ttslearn/pretrained/__init__.py
+++ b/ttslearn/pretrained/__init__.py
@@ -13,7 +13,7 @@ _urls = {
     "v0.2.1": "https://github.com/r9y9/ttslearn/releases/download/v0.2.1",
 }
 
-DEFAULT_CACHE_DIR = join(os.environ["HOME"], ".cache", "ttslearn")
+DEFAULT_CACHE_DIR = join(os.path.expanduser("~"), ".cache", "ttslearn")
 CACHE_DIR = os.environ.get("TTSLEARN_CACHE_DIR", DEFAULT_CACHE_DIR)
 
 


### PR DESCRIPTION
windows machines don't seem to have HOME env. variable

Ref:

- https://twitter.com/m_morise/status/1437693860797288448
- https://twitter.com/yamori81/status/1426875987413790727